### PR TITLE
fix/intra run artifacts

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,11 @@
       "Bash(dotnet test *)",
       "Bash(python3 *)",
       "Bash(git pushf *)",
-      "Bash(git rev-list *)"
+      "Bash(git rev-list *)",
+      "Bash(sed -n '138,146p' docs/ARCHITECTURE.md)",
+      "Bash(sed -n '340,356p' docs/ARCHITECTURE.md)",
+      "Bash(sed -n '126,136p' docs/WORKFLOWS_REFERENCE.md)",
+      "Bash(sed -n '98,106p' docs/CACHE_MANAGEMENT.md)"
     ]
   }
 }

--- a/.github/workflows/_benchmarks.yaml
+++ b/.github/workflows/_benchmarks.yaml
@@ -124,15 +124,23 @@ jobs:
           github-token: ${{ github.token }}
           github-actor: ${{ github.actor }}
 
-      # Retrieve compiled binaries from the build job
-      - name: Restore build artifacts from cache
-        uses: actions/cache/restore@v5
+      # Retrieve compiled binaries from the build job. Artifacts (not the cache) are the intra-run handoff:
+      # the cache gives no read-after-write guarantee within a run.
+      - name: Download build artifacts
+        uses: actions/download-artifact@v6
         with:
-          key: build-artifacts-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}-${{ github.run_id }}
-          fail-on-cache-miss: true
-          path: |
-            **/bin/${{ inputs.configuration }}
-            **/obj
+          pattern: build-artifacts-${{ runner.os }}-${{ inputs.configuration }}-*
+          merge-multiple: true
+          path: .
+
+      # A pattern download does not fail on zero matches, so verify explicitly (the equivalent of fail-on-cache-miss)
+      - name: Verify build artifacts were downloaded
+        shell: bash
+        run: |
+          find . -type d -path "*/bin/${{ inputs.configuration }}" -print -quit | grep -q . || {
+              echo "::error::No build artifacts were downloaded from the build job."
+              exit 1
+          }
 
       # Run benchmarks using BenchmarkDotNet and export JSON results
       - name: Run BenchmarkDotNet benchmarks

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -94,22 +94,22 @@ jobs:
           REFRESH_WF_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/RefreshLockfiles.yaml
         run: |
           if dotnet restore --locked-mode 2>&1 | grep -q "NU1004"; then
-            {
-              echo "## ⚠️ SDK version drift"
-              echo ""
-              echo "The NuGet lock files are stale — the runner's .NET SDK changed implicit"
-              echo "package versions (e.g. \`Microsoft.NET.ILLink.Tasks\`)."
-              echo ""
-              echo "**Fix (CI):** trigger the [Refresh Lock Files]($REFRESH_WF_URL) workflow"
-              echo "(scheduled every Monday 05:00 ET, or run manually via \`workflow_dispatch\`)."
-              echo ""
-              echo "**Fix (local):**"
-              echo "\`\`\`"
-              echo "sudo apt upgrade dotnet-sdk-10.0"
-              echo "restore-force-eval.sh"
-              echo "\`\`\`"
-              echo "Then re-push."
-            } >> "$GITHUB_STEP_SUMMARY"
+              {
+                  echo "## ⚠️ SDK version drift"
+                  echo ""
+                  echo "The NuGet lock files are stale — the runner's .NET SDK changed implicit"
+                  echo "package versions (e.g. \`Microsoft.NET.ILLink.Tasks\`)."
+                  echo ""
+                  echo "**Fix (CI):** trigger the [Refresh Lock Files]($REFRESH_WF_URL) workflow"
+                  echo "(scheduled every Monday 05:00 ET, or run manually via \`workflow_dispatch\`)."
+                  echo ""
+                  echo "**Fix (local):**"
+                  echo "\`\`\`"
+                  echo "sudo apt upgrade dotnet-sdk-10.0"
+                  echo "dotnet restore --force-evaluate"
+                  echo "\`\`\`"
+                  echo "Then re-push."
+              } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # Make the compiled binaries and intermediate files available to the downstream jobs (test, benchmarks, pack) of

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -120,8 +120,10 @@ jobs:
       - name: Compute build artifact slug
         id: slug
         shell: bash
+        env:
+          BUILD_PROJECT: ${{ inputs.build-project }}
         run: |
-          slug=$(echo '${{ inputs.build-project }}' | tr -c 'A-Za-z0-9.\n' '-')
+          slug=$(printf '%s' "${BUILD_PROJECT}" | tr -c 'A-Za-z0-9.\n' '-')
           echo "slug=${slug:-root}" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifacts

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -112,12 +112,25 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # Save compiled binaries and intermediate files to cache for downstream jobs
-      - name: Cache build artifacts
-        continue-on-error: true
-        uses: actions/cache/save@v5
+      # Make the compiled binaries and intermediate files available to the downstream jobs (test, benchmarks, pack) of
+      # this run. Artifacts -- not the cache -- are the intra-run handoff mechanism: the cache service is designed for
+      # cross-run reuse and gives no read-after-write guarantee, so a freshly saved entry may not be visible to a lookup
+      # seconds later (observed 2026-06-11: 4/4 deterministic restore misses ~25s after a verified save).
+      # The slug keeps artifact names unique across the build matrix legs (artifact names are immutable per run).
+      - name: Compute build artifact slug
+        id: slug
+        shell: bash
+        run: |
+          slug=$(echo '${{ inputs.build-project }}' | tr -c 'A-Za-z0-9.\n' '-')
+          echo "slug=${slug:-root}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
         with:
-          key: build-artifacts-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}-${{ github.run_id }}
+          name: build-artifacts-${{ runner.os }}-${{ inputs.configuration }}-${{ steps.slug.outputs.slug }}
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
           path: |
             **/bin/${{ inputs.configuration }}
             **/obj

--- a/.github/workflows/_clear_cache.yaml
+++ b/.github/workflows/_clear_cache.yaml
@@ -96,4 +96,4 @@ jobs:
               echo "**Reason:** ${REASON}"
               echo "### Remaining Caches"
               gh cache list --limit 20 || echo "No caches remaining"
-          } >> to_summary
+          } | to_summary

--- a/.github/workflows/_pack.yaml
+++ b/.github/workflows/_pack.yaml
@@ -40,7 +40,7 @@ on:
 
       skip-build-cache:
         description: >-
-          Skip restoring build artifacts from cache and build during pack instead.
+          Skip downloading the build job's artifacts and build during pack instead.
           Use for projects that don't require a separate build step (e.g., template packages).
         type: boolean
         default: false
@@ -83,16 +83,25 @@ jobs:
           github-token: ${{ github.token }}
           github-actor: ${{ github.actor }}
 
-      # Restore build artifacts from the build job cache
-      - name: Restore build artifacts from cache
+      # Retrieve compiled binaries from the build job. Artifacts (not the cache) are the intra-run handoff:
+      # the cache gives no read-after-write guarantee within a run.
+      - name: Download build artifacts
         if: ${{ !inputs.skip-build-cache }}
-        uses: actions/cache/restore@v5
+        uses: actions/download-artifact@v6
         with:
-          key: build-artifacts-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}-${{ github.run_id }}
-          fail-on-cache-miss: true
-          path: |
-            **/bin/${{ inputs.configuration }}
-            **/obj
+          pattern: build-artifacts-${{ runner.os }}-${{ inputs.configuration }}-*
+          merge-multiple: true
+          path: .
+
+      # A pattern download does not fail on zero matches, so verify explicitly (the equivalent of fail-on-cache-miss)
+      - name: Verify build artifacts were downloaded
+        if: ${{ !inputs.skip-build-cache }}
+        shell: bash
+        run: |
+          find . -type d -path "*/bin/${{ inputs.configuration }}" -print -quit | grep -q . || {
+              echo "::error::No build artifacts were downloaded from the build job."
+              exit 1
+          }
 
       - name: Pack
         id: pack

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -99,15 +99,14 @@ jobs:
           github-token: ${{ github.token }}
           github-actor: ${{ github.actor }}
 
-      # Retrieve compiled binaries from the build job to avoid recompilation
-      - name: Restore build artifacts from cache
-        uses: actions/cache/restore@v5
+      # Retrieve compiled binaries from the build job to avoid recompilation. Artifacts (not the cache) are the
+      # intra-run handoff: the cache gives no read-after-write guarantee within a run.
+      - name: Download build artifacts
+        uses: actions/download-artifact@v6
         with:
-          key: build-artifacts-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}-${{ github.run_id }}
-          fail-on-cache-miss: true
-          path: |
-            **/bin/${{ inputs.configuration }}
-            **/obj
+          pattern: build-artifacts-${{ runner.os }}-${{ inputs.configuration }}-*
+          merge-multiple: true
+          path: .
 
       - name: Verify the artifacts were restored and run the tests
         id: run-tests
@@ -121,7 +120,7 @@ jobs:
           ARTIFACT_PATH=$(find . -type d -path "*/bin/${{ inputs.configuration }}" | head -n 1)
 
           if [ -z "$ARTIFACT_PATH" ]; then
-              error "No build artifacts found in cache."
+              error "No build artifacts were downloaded from the build job."
               exit 1
           else
               info "Build artifacts found at: $ARTIFACT_PATH"

--- a/DEVOPS_WISHLIST.md
+++ b/DEVOPS_WISHLIST.md
@@ -6,23 +6,7 @@ problem actually bites), not pushed by the itch — or batched in a quarterly re
 
 The list is ordered by priority — add new items where they belong, not at the end.
 
-## 1. Replace intra-run build-artifacts cache with upload/download-artifact — **TRIGGERED**
-
-**What:** In `_build.yaml`, replace the `actions/cache/save` of `**/bin/{configuration}` + `**/obj` with
-`actions/upload-artifact`; in `_test.yaml`, `_pack.yaml`, and `_benchmarks.yaml`, replace `actions/cache/restore`
-(`fail-on-cache-miss: true`) with `actions/download-artifact`. Artifacts are synchronous and scoped to the run — no index
-propagation, no eviction, no cross-run semantics.
-
-**Why:** The cache service is designed for *cross-run* reuse and gives no read-after-write guarantee. Using it for
-*intra-run* job-to-job handoff fails when the cache index lags the save (observed 2026-06-11: key + version + scope all
-verified identical, save confirmed, restore ~25s later → not-found, 4/4 repros across repos while older entries restored
-fine in the same jobs). Artifacts are the intended mechanism for passing build outputs between jobs of one run.
-
-**Trigger:** FIRED — 2026-06-11, CI on main red on all four released repos.
-**Effort:** ~1-2 hours: 4 workflow files + retention tuning (`retention-days: 1` — these are throwaways) + remove the
-now-dead `build-artifacts-` prefix from `_clear_cache.yaml`'s allowlist and docs.
-
-## 2. Demote `latency`/`throughput` to record-only
+## 1. Demote `latency`/`throughput` to record-only
 
 **What:** Delete the `latency` and `throughput` threshold blocks from `BENCHER_ARGS` in
 `.github/workflows/_benchmarks.yaml`. Both measures stay uploaded and charted in Bencher — they just stop gating CI.

--- a/DEVOPS_WISHLIST.md
+++ b/DEVOPS_WISHLIST.md
@@ -40,3 +40,26 @@ repo-setup runs). The win is the standardized env contract + summary + dry-run, 
 **Trigger:** The next time a fleet-wide loop gets hand-written — e.g., rolling out the new git settings via
 `foreach-repo.sh -- repo-setup.sh --audit`.
 **Effort:** ~Half a day including docs.
+
+## 3. DevOps for vm2.DevOps — ShellCheck, tests, PR gates
+
+**What:** Give vm2.DevOps the same rigor it enforces on every other repo. Candidate pieces, roughly in value order:
+
+- **actionlint** in CI — static analysis purpose-built for GitHub Actions workflows (expression typos, invalid inputs,
+  shellcheck of embedded `run:` blocks — the YAML-embedded bash that the IDE ShellCheck extension never sees).
+- **ShellCheck as a CI gate** over `scripts/bash/` and `.github/scripts/` — the IDE extension covers interactive editing;
+  CI covers everything else (bulk edits, AI-generated changes, future contributors).
+- **Tests for the bash library** (e.g. bats-core) — 67 functions in `scripts/bash/lib/` with zero automated tests;
+  start with the highest-risk ones (`_sanitize.sh`, `_semver.sh`, `_args.sh`).
+- **PR gate** — a `Postrun-CI`-style required check on vm2.DevOps's own PRs running the above.
+- **(Bigger, separate decision)** Release channel for the reusable workflows: consumers reference `@main`, so every merge
+  deploys fleet-wide instantly and a PR cannot exercise the very workflows it changes. Tagged refs (`@v1`) or a
+  `stable` branch would decouple "merged" from "deployed" — at the cost of a promotion step.
+
+**Why:** vm2.DevOps has the largest blast radius in the ecosystem (all repos consume it `@main`) and the weakest gates —
+the inverse of how it should be. Today a workflow typo ships to every repo the moment it merges.
+
+**Trigger:** The first time a vm2.DevOps merge breaks a consumer repo's CI (or earlier, if a quiet week begs for it —
+but vm2.Repository ships first).
+**Effort:** actionlint + ShellCheck + gate: ~half a day. Library tests: incremental, start small. Release channel: a
+design discussion first.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@
       - [Utility Scripts (`/scripts/bash/`)](#utility-scripts-scriptsbash)
   - [Caching Strategy](#caching-strategy)
     - [NuGet Package Cache (dual-layer)](#nuget-package-cache-dual-layer)
-    - [Build Artifact Cache](#build-artifact-cache)
+    - [Build Artifact Handoff (workflow artifacts, not cache)](#build-artifact-handoff-workflow-artifacts-not-cache)
     - [Cache Cleanup](#cache-cleanup)
   - [Script Distribution](#script-distribution)
   - [NuGet Authentication](#nuget-authentication)
@@ -139,7 +139,8 @@ Concurrency group `ci-${{ github.workflow_ref }}` cancels in-progress runs on ne
 1. Checks out repository with full history (`fetch-depth: 0`) for MinVer version calculation.
 1. Restores NuGet packages (dual-layer cache — see [Caching Strategy](#2-caching-strategy)).
 1. Calls `build.sh` to compile the project.
-1. Saves build artifacts to cache with key `build-artifacts-{os}-{sha}-{configuration}-{run_id}`.
+1. Uploads the build outputs as a workflow artifact named `build-artifacts-{os}-{configuration}-{project-slug}`
+   (`retention-days: 1`) for the downstream jobs of the same run.
 
 #### Gate Job Pattern (`postrun-ci`)
 
@@ -343,16 +344,22 @@ The build pipeline uses a dual-layer NuGet cache and a build artifact cache.
     nuget-{os}-                          (any week)
     ```
 
-### Build Artifact Cache
+### Build Artifact Handoff (workflow artifacts, not cache)
 
-The build job saves compiled outputs (`**/bin/{config}` and `**/obj`) under key
-`build-artifacts-{os}-{sha}-{configuration}-{run_id}`. Downstream jobs (test, benchmarks, pack) restore from this cache to avoid
-rebuilding.
+The build job uploads the compiled outputs (`**/bin/{config}` and `**/obj`) as a **workflow artifact** named
+`build-artifacts-{os}-{configuration}-{project-slug}` with `retention-days: 1`. Downstream jobs (test, benchmarks, pack)
+download it by pattern (`merge-multiple: true`) to avoid rebuilding.
+
+This intra-run handoff deliberately does **not** use the Actions cache: the cache service is designed for cross-run reuse
+and gives no read-after-write guarantee — a freshly saved entry may not be visible to a lookup seconds later (observed
+2026-06-11: 4/4 deterministic restore misses ~25s after a verified save, while the same key restored fine hours later).
+Workflow artifacts are synchronous and scoped to the run.
 
 ### Cache Cleanup
 
 The `_clear_cache.yaml` workflow provides emergency cleanup. It restricts deletions to three allowlisted prefixes: `nuget-`,
-`build-artifacts-`, and `bencher-cli-`.
+`build-artifacts-`, and `bencher-cli-`. (The `build-artifacts-` prefix is legacy — these caches are no longer created; the
+prefix remains allowlisted only to purge leftover entries until they age out.)
 
 ## Script Distribution
 

--- a/docs/CACHE_MANAGEMENT.md
+++ b/docs/CACHE_MANAGEMENT.md
@@ -100,7 +100,7 @@ Allowed patterns (enforced by allowlist):
 | Pattern              | What it clears          |
 | :------------------- | :---------------------- |
 | `nuget-`             | NuGet package caches    |
-| `build-artifacts-`   | Build artifact caches   |
+| `build-artifacts-`   | Legacy build artifact caches (no longer created — build outputs now travel as workflow artifacts; prefix kept to purge leftovers) |
 | `bencher-cli-`       | Bencher CLI cache       |
 
 ## MTP v1 vs v2 Lock File Interaction

--- a/docs/WORKFLOWS_REFERENCE.md
+++ b/docs/WORKFLOWS_REFERENCE.md
@@ -11,7 +11,7 @@
   - [\_build.yaml](#_buildyaml)
     - [Inputs](#inputs-1)
     - [Permissions](#permissions)
-    - [Cache Keys](#cache-keys)
+    - [Cache Keys and Artifacts](#cache-keys-and-artifacts)
     - [Script](#script)
   - [\_test.yaml](#_testyaml)
     - [Inputs](#inputs-2)
@@ -124,12 +124,12 @@ Compiles the project and caches build artifacts for downstream jobs.
     contents: read
     packages: read
 
-### Cache Keys
+### Cache Keys and Artifacts
 
-| Cache                | Key Pattern                                                          |
-| :------------------- | :------------------------------------------------------------------- |
-| NuGet (weekly)       | `nuget-{os}-{YYYY-WVV}-{lockfile-hash}`                              |
-| Build artifacts      | `build-artifacts-{os}-{sha}-{configuration}-{run_id}`                |
+| Mechanism                     | Name / Key Pattern                                                   |
+| :---------------------------- | :------------------------------------------------------------------- |
+| NuGet cache (weekly)          | `nuget-{os}-{YYYY-WVV}-{lockfile-hash}`                              |
+| Build artifacts (workflow artifact, `retention-days: 1`) | `build-artifacts-{os}-{configuration}-{project-slug}` |
 
 ### Script
 


### PR DESCRIPTION
# Summary

<!-- Brief description of what this PR does and why. -->

## Commits

- fix(ci): pass build outputs between jobs as workflow artifacts, not cache
- fix: add additional sed commands to settings for improved documentation extraction
- fix: update SDK version drift message for clarity and accuracy in build workflow fix: correct output redirection in cache clearing workflow summary

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [ ] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary