### PR TITLE
Fix diff-shared.sh and setup-repo.sh crash on --help

### DIFF
--- a/.github/scripts/build.args.sh
+++ b/.github/scripts/build.args.sh
@@ -62,6 +62,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/changelog-and-tag.args.sh
+++ b/.github/scripts/changelog-and-tag.args.sh
@@ -56,6 +56,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/compute-prerelease-version.args.sh
+++ b/.github/scripts/compute-prerelease-version.args.sh
@@ -45,6 +45,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/compute-release-version.args.sh
+++ b/.github/scripts/compute-release-version.args.sh
@@ -40,6 +40,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/download-artifact.args.sh
+++ b/.github/scripts/download-artifact.args.sh
@@ -68,6 +68,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/pack.args.sh
+++ b/.github/scripts/pack.args.sh
@@ -63,6 +63,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/publish-package.args.sh
+++ b/.github/scripts/publish-package.args.sh
@@ -83,6 +83,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/rebuild-bench-history-run.args.sh
+++ b/.github/scripts/rebuild-bench-history-run.args.sh
@@ -93,6 +93,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/rebuild-bench-history.args.sh
+++ b/.github/scripts/rebuild-bench-history.args.sh
@@ -47,6 +47,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/run-benchmarks.args.sh
+++ b/.github/scripts/run-benchmarks.args.sh
@@ -73,6 +73,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/run-tests.args.sh
+++ b/.github/scripts/run-tests.args.sh
@@ -74,6 +74,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet \
         --header "Script Arguments:" \
         dry_run \

--- a/.github/scripts/validate-commits.args.sh
+++ b/.github/scripts/validate-commits.args.sh
@@ -35,7 +35,7 @@ function get_arguments()
                 ;;
         esac
     done
-
+    usage_if_requested
     dump_vars --force --quiet --markdown \
         --header "Script Arguments:" \
         dry_run verbose quiet \

--- a/.github/scripts/validate-input.args.sh
+++ b/.github/scripts/validate-input.args.sh
@@ -120,6 +120,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_vars --force --quiet \
         --header "Script Arguments:" \
         dry_run \

--- a/scripts/bash/diff-shared.args.sh
+++ b/scripts/bash/diff-shared.args.sh
@@ -78,6 +78,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
 }
 
 declare -xr action_ignore

--- a/scripts/bash/diff-shared.sh
+++ b/scripts/bash/diff-shared.sh
@@ -23,6 +23,7 @@ declare -rx lib_dir
 # Imported constants
 #===============================
 # imported environment variables and defaults:
+declare -x _ignore
 declare -rx default_sot
 declare -rxa sources_of_truth
 declare -rxa vm2_repositories
@@ -46,16 +47,22 @@ declare -rxi err_repo_with_no_ci
 declare -rxi err_dir_with_no_ci
 declare -rxi err_not_git_directory
 declare -rxi err_dir_with_ci
+declare -rxi err_logic_error
 
-source "${script_dir}/diff-shared.functions.sh"
-source "${script_dir}/diff-shared.args.sh"
-source "${script_dir}/diff-shared.usage.sh"
+# shellcheck disable=SC1091
+{
+    source "${script_dir}/diff-shared.functions.sh"
+    source "${script_dir}/diff-shared.args.sh"
+    source "${script_dir}/diff-shared.usage.sh"
+}
 
 #===============================
 # arguments:
 #===============================
 declare -x vm2_repos="${VM2_REPOS:-}"
+declare -x vm2_sot_repo_name
 declare -x sot=$default_sot
+declare -xa common_args
 declare -xa target_repos=()         # the target repositories specified as arguments. If not specified, the current directory is used as the only target repo.
 declare -xA selectors_actions=()    # array [file] => [action string] for files specified on the CLI with --file* options
 declare -x diff_only="false"        # if true, only show the differences without asking the user to take any actions. This is useful for CI validation of the shared content. In this mode, the actions are ignored and the summary file will not contain the Action column.
@@ -64,6 +71,7 @@ declare -x summary_file=""          # the file where the summary of the differen
 #===============================
 # Script shared variables:
 #===============================
+declare -x action_ignore action_merge_or_copy action_ask_to_merge action_ask_to_copy action_merge action_copy
 declare -xi rc="$success"
 declare -xa arguments=(             # array of all arguments for logging and debugging purposes
     vm2_repos

--- a/scripts/bash/diff-shared.sh
+++ b/scripts/bash/diff-shared.sh
@@ -54,7 +54,7 @@ source "${script_dir}/diff-shared.usage.sh"
 #===============================
 # arguments:
 #===============================
-declare -x vm2_repos=""
+declare -x vm2_repos="${VM2_REPOS:-}"
 declare -x sot=$default_sot
 declare -xa target_repos=()         # the target repositories specified as arguments. If not specified, the current directory is used as the only target repo.
 declare -xA selectors_actions=()    # array [file] => [action string] for files specified on the CLI with --file* options

--- a/scripts/bash/diff-shared.sh
+++ b/scripts/bash/diff-shared.sh
@@ -59,7 +59,7 @@ declare -rxi err_logic_error
 #===============================
 # arguments:
 #===============================
-declare -x vm2_repos="${VM2_REPOS:-}"
+declare -x vm2_repos="${VM2_REPOS:-$HOME/repos/vm2}"
 declare -x vm2_sot_repo_name
 declare -x sot=$default_sot
 declare -xa common_args

--- a/scripts/bash/lib/_args.sh
+++ b/scripts/bash/lib/_args.sh
@@ -24,6 +24,7 @@ declare -rxi negative
 declare -rxi err_invalid_arguments
 declare -rxi err_argument_type
 declare -rxi err_argument_value
+declare -rxi err_missing_argument
 declare -rxi err_not_overridden
 declare -rxi err_logic_error
 
@@ -367,6 +368,9 @@ function get_table_format()
     return "$success"
 }
 
+declare -x usage_requested=""
+declare -x vm2_option="${VM2_REPOS:-}"
+
 #-------------------------------------------------------------------------------
 # Summary: Processes common command-line arguments like --quiet, --verbose, --trace, --dry-run.
 # Parameters:
@@ -407,6 +411,25 @@ function get_common_arg()
     esac
 
     return "$positive" # it was a common argument and was processed
+}
+
+#-------------------------------------------------------------------------------
+# Summary: Exits the script if a usage request was made via command-line arguments.
+# Parameters: none
+# Returns:
+#   Exit code: 0 if no usage was requested, otherwise exits the script
+# Side Effects: May call the usage function and exit the script
+# Usage: usage_if_requested
+# Example:
+#     usage_if_requested
+#-------------------------------------------------------------------------------
+function usage_if_requested()
+{
+    case "${usage_requested}" in
+        short ) usage false;;
+        long  ) usage true;;
+        *     ) return 0;;
+    esac
 }
 
 #-------------------------------------------------------------------------------

--- a/scripts/bash/lib/_args.sh
+++ b/scripts/bash/lib/_args.sh
@@ -369,7 +369,6 @@ function get_table_format()
 }
 
 declare -x usage_requested=""
-declare -x vm2_option="${VM2_REPOS:-}"
 
 #-------------------------------------------------------------------------------
 # Summary: Processes common command-line arguments like --quiet, --verbose, --trace, --dry-run.
@@ -399,8 +398,8 @@ function get_common_arg()
     run_long_usage=false
 
     case "${1,,}" in
-        --help          ) usage true;;
-        -h|-\?          ) usage false;;
+        --help          ) usage_requested="long";;
+        -h|-\?          ) usage_requested="short";;
         -v|--verbose    ) set_verbose ;;
         -q|--quiet      ) set_quiet ;;
         -x|--trace      ) set_trace_enabled ;;

--- a/scripts/bash/move-commits-to-branch.args.sh
+++ b/scripts/bash/move-commits-to-branch.args.sh
@@ -55,4 +55,5 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
 }

--- a/scripts/bash/re-tag.args.sh
+++ b/scripts/bash/re-tag.args.sh
@@ -8,6 +8,11 @@ declare -xr lib_dir
 
 declare -rxi err_missing_argument
 
+declare -x delete_mode
+declare -x del_tag
+declare -x old_tag
+declare -x new_tag
+
 function dump_all_variables()
 {
     dump_vars --quiet \

--- a/scripts/bash/re-tag.args.sh
+++ b/scripts/bash/re-tag.args.sh
@@ -51,5 +51,6 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_all_variables
 }

--- a/scripts/bash/rename-branch.args.sh
+++ b/scripts/bash/rename-branch.args.sh
@@ -35,6 +35,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
 }
 
 dump_all_variables()

--- a/scripts/bash/repo-setup.args.sh
+++ b/scripts/bash/repo-setup.args.sh
@@ -110,6 +110,7 @@ function get_arguments()
                 ;;
         esac
     done
+    usage_if_requested
     dump_args
 }
 

--- a/scripts/bash/repo-setup.sh
+++ b/scripts/bash/repo-setup.sh
@@ -66,11 +66,14 @@ declare -xi github_actions_app_id=0
 
 declare -x vm2=""
 
-source "${script_dir}/repo-setup.args.sh"
-source "${script_dir}/repo-setup.usage.sh"
-source "${script_dir}/repo-setup.defaults.sh"
-source "${script_dir}/repo-setup.functions.sh"
-source "${script_dir}/repo-setup.audit.sh"
+# shellcheck disable=SC1091
+{
+    source "${script_dir}/repo-setup.args.sh"
+    source "${script_dir}/repo-setup.usage.sh"
+    source "${script_dir}/repo-setup.defaults.sh"
+    source "${script_dir}/repo-setup.functions.sh"
+    source "${script_dir}/repo-setup.audit.sh"
+}
 
 get_arguments "$@"
 

--- a/scripts/bash/repo-setup.sh
+++ b/scripts/bash/repo-setup.sh
@@ -47,7 +47,7 @@ declare -x use_https=false
 declare -x repo_owner=${ORGANIZATION:-$default_owner}
 declare -rx sot=$default_sot
 
-declare -x vm2_repos=""
+declare -x vm2_repos="${VM2_REPOS:-}"
 declare -x repo_name=""
 declare -x repo=""
 declare -x repo_url=""

--- a/scripts/bash/repo-setup.sh
+++ b/scripts/bash/repo-setup.sh
@@ -47,7 +47,7 @@ declare -x use_https=false
 declare -x repo_owner=${ORGANIZATION:-$default_owner}
 declare -rx sot=$default_sot
 
-declare -x vm2_repos="${VM2_REPOS:-}"
+declare -x vm2_repos="${VM2_REPOS:-${HOME}/repos/vm2}"
 declare -x repo_name=""
 declare -x repo=""
 declare -x repo_url=""


### PR DESCRIPTION
# Summary

Fix: diff-shared.sh and setup-repo.sh crash on --help by consume all parameters and then show the usage if requested

## Commits

- fix: diff-shared.sh and setup-repo.sh crash on --help by consume all parameters and then show the usage if requested

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [ ] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary